### PR TITLE
AM62P: Add dtso files for single-link display configurations.

### DIFF
--- a/am62p/simultaneous_display_examples/k3-am62p5-sk-rocktech-rk101-panel-cloned-mode.dtso
+++ b/am62p/simultaneous_display_examples/k3-am62p5-sk-rocktech-rk101-panel-cloned-mode.dtso
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/**
+ * Rocktech Panel (single-link lvds) with AM62P-SK EVM in cloned mode
+ *
+ * AM62P-SKEVM: https://www.ti.com/tool/SK-AM62P-LP
+ *
+ * Copyright (C) 2024 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&{/} {
+	display0 {
+		compatible = "rocktech,rk101ii01d-ct", "panel-simple";
+		port {
+			lcd0_in: endpoint {
+				remote-endpoint = <&oldi0_dss0_out>;
+			};
+		};
+	};
+
+	display1 {
+		compatible = "rocktech,rk101ii01d-ct", "panel-simple";
+		port {
+			lcd1_in: endpoint {
+				remote-endpoint = <&oldi1_dss0_out>;
+			};
+		};
+	};
+};
+
+&dss0 {
+	status = "okay";
+};
+
+&oldi0_dss0 {
+	status = "okay";
+	ti,companion-oldi = <&oldi1_dss0>;
+};
+
+&oldi1_dss0 {
+	status = "okay";
+	ti,secondary-oldi;
+};
+
+&oldi0_dss0_ports {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	port@0 {
+		reg = <0>;
+		oldi0_dss0_in: endpoint {
+			remote-endpoint = <&dss0_dpi0_out0>;
+		};
+	};
+
+	port@1 {
+		reg = <1>;
+		oldi0_dss0_out: endpoint {
+			remote-endpoint = <&lcd0_in>;
+		};
+	};
+};
+
+&oldi1_dss0_ports {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	port@0 {
+		reg = <0>;
+		oldi1_dss0_in: endpoint {
+			remote-endpoint = <&dss0_dpi0_out1>;
+		};
+	};
+
+	port@1 {
+		reg = <1>;
+		oldi1_dss0_out: endpoint {
+			remote-endpoint = <&lcd1_in>;
+		};
+	};
+};
+
+&dss0_ports {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* VP1: Output to OLDI */
+	port@0 {
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		dss0_dpi0_out0: endpoint@0 {
+			reg = <0>;
+			remote-endpoint = <&oldi0_dss0_in>;
+		};
+		dss0_dpi0_out1: endpoint@1 {
+			reg = <1>;
+			remote-endpoint = <&oldi1_dss0_in>;
+		};
+	};
+};

--- a/am62p/simultaneous_display_examples/k3-am62p5-sk-rocktech-rk101-panel-independent-mode.dtso
+++ b/am62p/simultaneous_display_examples/k3-am62p5-sk-rocktech-rk101-panel-independent-mode.dtso
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/**
+ * Rocktech Panel (single-link lvds) with AM62P-SK EVM in independent mode
+ *
+ * AM62P-SKEVM: https://www.ti.com/tool/SK-AM62P-LP
+ *
+ * Copyright (C) 2024 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&{/} {
+	display0 {
+		compatible = "rocktech,rk101ii01d-ct", "panel-simple";
+
+		port {
+			lcd0_in: endpoint {
+				remote-endpoint = <&oldi0_dss0_out>;
+			};
+		};
+	};
+
+	display1 {
+		compatible = "rocktech,rk101ii01d-ct", "panel-simple";
+
+		port {
+			lcd1_in: endpoint {
+				remote-endpoint = <&oldi1_dss1_out>;
+			};
+		};
+	};
+};
+
+&dss0 {
+	status = "okay";
+};
+
+&dss1 {
+	status = "okay";
+    assigned-clocks = <&k3_clks 235 7>,
+                      <&k3_clks 241 0>;
+	assigned-clock-parents = <&k3_clks 235 9>, /* OLDI TX1 driven by PLL18 and DSS1 VP0 */
+                            <&k3_clks 241 1>;  /* PLL18 for DSS1 VP0 */
+};
+
+&oldi0_dss0 {
+	status = "okay";
+};
+
+&oldi1_dss1 {
+	status = "okay";	
+};
+
+&oldi0_dss0_ports {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	port@0 {
+		reg = <0>;
+
+		oldi0_dss0_in: endpoint {
+			remote-endpoint = <&dss0_dpi0_out0>;
+		};
+	};
+
+	port@1 {
+		reg = <1>;
+
+		oldi0_dss0_out: endpoint {
+			remote-endpoint = <&lcd0_in>;
+		};
+	};
+};
+
+&oldi1_dss1_ports {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	port@0 {
+		reg = <0>;
+
+		oldi1_dss1_in: endpoint {
+			remote-endpoint = <&dss1_dpi0_out1>;
+		};
+	};
+
+	port@1 {
+		reg = <1>;
+
+		oldi1_dss1_out: endpoint {
+			remote-endpoint = <&lcd1_in>;
+		};
+	};
+};
+
+&dss0_ports {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* DSS0 VP1: Output to OLDI0 */
+	port@0 {
+		reg = <0>;
+
+		dss0_dpi0_out0: endpoint {
+			remote-endpoint = <&oldi0_dss0_in>;
+		};
+	};
+};
+
+&dss1_ports {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* DSS1 VP1: Output to OLDI1 */
+	port@0 {
+		reg = <0>;
+
+		dss1_dpi0_out1: endpoint {
+			remote-endpoint = <&oldi1_dss1_in>;
+		};
+	};
+};


### PR DESCRIPTION
Add k3-am62p5-sk-rocktech-rk101-panel-cloned-mode.dtso for configuring 2 Single-Link OLDI displays working in cloned mode on AM62Px SoC. Add k3-am62p5-sk-rocktech-rk101-panel-independent-mode.dtso for configuring 2 Single-Link OLDI displays working in independent mode on AM62Px SoC.