### PR TITLE
collaterals: appnotes: Add patches for sdaa320

### DIFF
--- a/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0001-recipes-multimedia-Add-pipewire-configuration-files.patch
+++ b/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0001-recipes-multimedia-Add-pipewire-configuration-files.patch
@@ -1,0 +1,169 @@
+From a95e2a29abfe03e754e5ec136c96b85671ca9b83 Mon Sep 17 00:00:00 2001
+From: Paresh Bhagat <p-bhagat@ti.com>
+Date: Sun, 8 Feb 2026 16:25:54 +0530
+Subject: [PATCH 1/3] recipes-multimedia: Add pipewire configuration files
+
+- Add 90-pipewire-sink.conf and 91-pipewire-source.conf for 8 channel
+  audio playback and capture.
+- Add pipewire_%.bbappend recipe extension
+- Add new pipewire.service file
+
+Signed-off-by: Paresh Bhagat <p-bhagat@ti.com>
+---
+ .../pipewire/pipewire-arago.inc               | 28 ++++++++++++++
+ .../am62dxx-evm/90-pipewire-sink.conf         | 21 +++++++++++
+ .../am62dxx-evm/91-pipewire-source.conf       | 21 +++++++++++
+ .../pipewire/pipewire/pipewire.service        | 37 +++++++++++++++++++
+ .../pipewire/pipewire_%.bbappend              |  4 ++
+ 5 files changed, 111 insertions(+)
+ create mode 100644 meta-arago-distro/recipes-multimedia/pipewire/pipewire-arago.inc
+ create mode 100644 meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/90-pipewire-sink.conf
+ create mode 100644 meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/91-pipewire-source.conf
+ create mode 100644 meta-arago-distro/recipes-multimedia/pipewire/pipewire/pipewire.service
+ create mode 100644 meta-arago-distro/recipes-multimedia/pipewire/pipewire_%.bbappend
+
+diff --git a/meta-arago-distro/recipes-multimedia/pipewire/pipewire-arago.inc b/meta-arago-distro/recipes-multimedia/pipewire/pipewire-arago.inc
+new file mode 100644
+index 00000000..b3e0c555
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/pipewire/pipewire-arago.inc
+@@ -0,0 +1,28 @@
++PR:append = ".arago1"
++
++# Pipewire service for all platforms
++FILESEXTRAPATHS:prepend := "${THISDIR}/pipewire:"
++SRC_URI:append = " file://pipewire.service"
++
++# AM62D-specific config files
++FILESEXTRAPATHS:prepend:am62dxx-evm := "${THISDIR}/pipewire:"
++SRC_URI:append:am62dxx-evm = " \
++    file://90-pipewire-sink.conf \
++    file://91-pipewire-source.conf \
++"
++
++do_install:append() {
++    install -d ${D}${systemd_system_unitdir}
++    install -m 0644 ${UNPACKDIR}/pipewire.service ${D}${systemd_system_unitdir}/
++}
++
++do_install:append:am62dxx-evm() {
++    install -d ${D}${sysconfdir}/pipewire/pipewire.conf.d
++    install -m 0644 ${UNPACKDIR}/90-pipewire-sink.conf ${D}${sysconfdir}/pipewire/pipewire.conf.d/
++    install -m 0644 ${UNPACKDIR}/91-pipewire-source.conf ${D}${sysconfdir}/pipewire/pipewire.conf.d/
++}
++
++FILES:${PN} += " ${sysconfdir}"
++
++PACKAGECONFIG:append = " pipewire-jack"
++PACKAGECONFIG:remove = "jack"
+diff --git a/meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/90-pipewire-sink.conf b/meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/90-pipewire-sink.conf
+new file mode 100644
+index 00000000..86481af6
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/90-pipewire-sink.conf
+@@ -0,0 +1,21 @@
++# PipeWire source configuration for AM62D.
++
++context.objects = [
++    {
++        factory = adapter
++        args = {
++            factory.name           = api.alsa.pcm.sink
++            node.name              = "alsa_audio_sink"
++            node.description       = "Audio Output"
++            media.class            = "Audio/Sink"
++            api.alsa.period-size   = 1024
++            api.alsa.headroom      = 0
++            api.alsa.disable-mmap  = false
++            api.alsa.disable-batch = false
++            api.alsa.path          = "hw:AM62D2EVM,0"
++            audio.rate             = 48000
++            audio.channels         = 8
++            audio.position         = [ FL FR FC LFE RL RR SL SR ]
++        }
++    }
++]
+diff --git a/meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/91-pipewire-source.conf b/meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/91-pipewire-source.conf
+new file mode 100644
+index 00000000..71b7ec76
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/pipewire/pipewire/am62dxx-evm/91-pipewire-source.conf
+@@ -0,0 +1,21 @@
++# PipeWire source configuration for AM62D.
++
++context.objects = [
++    {
++        factory = adapter
++        args = {
++            factory.name           = api.alsa.pcm.source
++            node.name              = "alsa_audio_source"
++            node.description       = "Audio Input"
++            media.class            = "Audio/Source"
++            api.alsa.period-size   = 1024
++            api.alsa.headroom      = 0
++            api.alsa.disable-mmap  = false
++            api.alsa.disable-batch = false
++            api.alsa.path          = "hw:AM62D2EVM,0"
++            audio.rate             = 48000
++            audio.channels         = 8
++            audio.position         = [ FL FR FC LFE RL RR SL SR ]
++        }
++    }
++]
+diff --git a/meta-arago-distro/recipes-multimedia/pipewire/pipewire/pipewire.service b/meta-arago-distro/recipes-multimedia/pipewire/pipewire/pipewire.service
+new file mode 100644
+index 00000000..29b1775e
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/pipewire/pipewire/pipewire.service
+@@ -0,0 +1,37 @@
++[Unit]
++Description=PipeWire Multimedia Service
++# Ensure kernel modules are loaded and udev has finished device processing
++After=systemd-modules-load.service systemd-udev-settle.service
++
++# We require pipewire.socket to be active before starting the daemon, because
++# while it is possible to use the service without the socket, it is not clear
++# why it would be desirable.
++#
++# Installing pipewire and doing `systemctl start pipewire` will not get the
++# socket started, which might be confusing and problematic if the server is to
++# be restarted later on, as the client autospawn feature might kick in. Also, a
++# start of the socket unit will fail, adding to the confusion.
++#
++# After=pipewire.socket is not needed, as it is already implicit in the
++# socket-service relationship, see systemd.socket(5).
++Requires=pipewire.socket
++
++[Service]
++LockPersonality=yes
++MemoryDenyWriteExecute=yes
++NoNewPrivileges=yes
++SystemCallArchitectures=native
++SystemCallFilter=@system-service
++Type=simple
++AmbientCapabilities=CAP_SYS_NICE
++ExecStart=/usr/bin/pipewire
++Restart=on-failure
++RestartSec=2
++RuntimeDirectory=pipewire
++RuntimeDirectoryPreserve=yes
++User=pipewire
++Environment=PIPEWIRE_RUNTIME_DIR=%t/pipewire
++
++[Install]
++Also=pipewire.socket pipewire-manager.socket
++WantedBy=default.target
+\ No newline at end of file
+diff --git a/meta-arago-distro/recipes-multimedia/pipewire/pipewire_%.bbappend b/meta-arago-distro/recipes-multimedia/pipewire/pipewire_%.bbappend
+new file mode 100644
+index 00000000..dc32422b
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/pipewire/pipewire_%.bbappend
+@@ -0,0 +1,4 @@
++PIPEWIRE_ARAGO = ""
++PIPEWIRE_ARAGO:arago = "pipewire-arago.inc"
++
++require ${PIPEWIRE_ARAGO}
+-- 
+2.34.1
+

--- a/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0001-ti-apps-launcher-Remove-pulseaudio-service-dependenc.patch
+++ b/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0001-ti-apps-launcher-Remove-pulseaudio-service-dependenc.patch
@@ -1,0 +1,28 @@
+From c5e7cf48714d65a7cbf6854ae55cb4a6bf79f564 Mon Sep 17 00:00:00 2001
+From: Paresh Bhagat <p-bhagat@ti.com>
+Date: Wed, 18 Mar 2026 16:34:01 +0530
+Subject: [PATCH] ti-apps-launcher: Remove pulseaudio-service dependency
+
+Remove pulseaudio-service from RDEPENDS as we transition to PipeWire
+support for audio functionality.
+
+Signed-off-by: Paresh Bhagat <p-bhagat@ti.com>
+---
+ .../recipes-demos/ti-apps-launcher/ti-apps-launcher.bb           | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+index ea7a6b6..7f7ce4f 100644
+--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
++++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+@@ -34,7 +34,6 @@ RDEPENDS:${PN} = "\
+     qt3d \
+     bash \
+     seva-launcher \
+-    pulseaudio-service \
+     qtdeclarative-qmlplugins \
+     qtwayland-qmlplugins \
+     qtdeclarative-tools \
+-- 
+2.34.1
+

--- a/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0002-recipes-multimedia-Add-wireplumber-audio-configurati.patch
+++ b/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0002-recipes-multimedia-Add-wireplumber-audio-configurati.patch
@@ -1,0 +1,138 @@
+From 25ffa993dc8b2a1ae8c2c40bed79b6e0ddfdc3b5 Mon Sep 17 00:00:00 2001
+From: Paresh Bhagat <p-bhagat@ti.com>
+Date: Sun, 8 Feb 2026 16:26:11 +0530
+Subject: [PATCH 2/3] recipes-multimedia: Add wireplumber audio configuration
+
+- Add set-audio-defaults.sh script for audio setup
+- Add set-audio-defaults.service systemd service
+- Add wireplumber_%.bbappend recipe extension
+
+Signed-off-by: Paresh Bhagat <p-bhagat@ti.com>
+---
+ .../wireplumber/wireplumber-arago.inc         | 33 +++++++++++++++++++
+ .../wireplumber/set-audio-defaults.service    | 21 ++++++++++++
+ .../wireplumber/set-audio-defaults.sh         | 32 ++++++++++++++++++
+ .../wireplumber/wireplumber_%.bbappend        |  4 +++
+ 4 files changed, 90 insertions(+)
+ create mode 100644 meta-arago-distro/recipes-multimedia/wireplumber/wireplumber-arago.inc
+ create mode 100644 meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.service
+ create mode 100755 meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.sh
+ create mode 100644 meta-arago-distro/recipes-multimedia/wireplumber/wireplumber_%.bbappend
+
+diff --git a/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber-arago.inc b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber-arago.inc
+new file mode 100644
+index 00000000..6325d26c
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber-arago.inc
+@@ -0,0 +1,33 @@
++PR:append = ".arago1"
++
++FILESEXTRAPATHS:prepend:am62dxx-evm := "${THISDIR}/wireplumber:"
++
++SRC_URI:append:am62dxx-evm = " \
++    file://set-audio-defaults.sh \
++    file://set-audio-defaults.service \
++"
++
++inherit systemd
++
++# Enable wireplumber for all platforms
++SYSTEMD_PACKAGES = "${PN}"
++SYSTEMD_SERVICE:${PN} = "wireplumber.service"
++SYSTEMD_AUTO_ENABLE:${PN} = "enable"
++
++do_install:append:am62dxx-evm() {
++    # Install the script
++    install -d ${D}${bindir}
++    install -m 0755 ${UNPACKDIR}/set-audio-defaults.sh ${D}${bindir}/
++
++    # Install the systemd service file
++    install -d ${D}${systemd_system_unitdir}
++    install -m 0644 ${UNPACKDIR}/set-audio-defaults.service ${D}${systemd_system_unitdir}/
++}
++
++SYSTEMD_PACKAGES:am62dxx-evm = "${PN}"
++SYSTEMD_SERVICE:${PN}:am62dxx-evm = "wireplumber.service set-audio-defaults.service"
++SYSTEMD_AUTO_ENABLE:${PN}:am62dxx-evm = "enable"
++
++FILES:${PN} += " \
++    ${bindir} \
++"
+diff --git a/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.service b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.service
+new file mode 100644
+index 00000000..191b89f5
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.service
+@@ -0,0 +1,21 @@
++[Unit]
++Description=Set PipeWire Default Audio Devices
++# Wait for pipewire and wireplumber services to be started
++After=pipewire.service wireplumber.service
++# Ensure udev has settled so audio devices are available
++After=systemd-udev-settle.service
++Wants=pipewire.service wireplumber.service
++
++[Service]
++Type=oneshot
++ExecStart=/usr/bin/set-audio-defaults.sh
++StandardOutput=append:/var/log/set-audio-defaults-output.log
++StandardError=append:/var/log/set-audio-defaults-error.log
++RemainAfterExit=yes
++TimeoutStartSec=90
++# Restart on failure with delay
++Restart=on-failure
++RestartSec=5
++
++[Install]
++WantedBy=multi-user.target
+diff --git a/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.sh b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.sh
+new file mode 100755
+index 00000000..49be177e
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber/set-audio-defaults.sh
+@@ -0,0 +1,32 @@
++#!/bin/sh
++
++# Wait for WirePlumber to be ready
++i=1
++while [ "$i" -le 30 ]; do
++    wpctl status >/dev/null 2>&1 && break
++    sleep 1
++    i=$((i + 1))
++done
++
++# Additional delay for nodes to appear
++sleep 2
++
++# Find audio sink ID
++SINK_ID=$(pw-cli info alsa_audio_sink 2>/dev/null | head -n 1 | awk '{print $2}')
++if [ -n "$SINK_ID" ]; then
++    wpctl set-default "$SINK_ID"
++    echo "Set default sink to ID: $SINK_ID (alsa_audio_sink)"
++else
++    echo "Could not find alsa_audio_sink"
++fi
++
++# Find audio source ID
++SOURCE_ID=$(pw-cli info alsa_audio_source 2>/dev/null | head -n 1 | awk '{print $2}')
++if [ -n "$SOURCE_ID" ]; then
++    wpctl set-default "$SOURCE_ID"
++    echo "Set default source to ID: $SOURCE_ID (alsa_audio_source)"
++else
++    echo "Could not find alsa_audio_source"
++fi
++
++echo "Done"
+diff --git a/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber_%.bbappend b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber_%.bbappend
+new file mode 100644
+index 00000000..541b2963
+--- /dev/null
++++ b/meta-arago-distro/recipes-multimedia/wireplumber/wireplumber_%.bbappend
+@@ -0,0 +1,4 @@
++WIREPLUMBER_ARAGO = ""
++WIREPLUMBER_ARAGO:arago = "wireplumber-arago.inc"
++
++require ${WIREPLUMBER_ARAGO}
+-- 
+2.34.1
+

--- a/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0003-recipes-core-arago-default-image-Add-pipewire-audio-.patch
+++ b/collaterals/appnotes/sdaa320-Enable_PipeWire_on_TI_Sitara_Devices/0003-recipes-core-arago-default-image-Add-pipewire-audio-.patch
@@ -1,0 +1,54 @@
+From d1e1bde6a986d1fc760023be07e37b506f8dc9e8 Mon Sep 17 00:00:00 2001
+From: Paresh Bhagat <p-bhagat@ti.com>
+Date: Tue, 17 Feb 2026 23:01:01 +0530
+Subject: [PATCH 3/3] recipes-core: arago-default-image: Add pipewire audio
+ stack support
+
+Add pipewire and wireplumber audio stack support for all am62* devices.
+- Include pipewire core components and tools.
+- Include wireplumber session manager.
+- Add GStreamer pipewire plugin.
+- Configure pipewire with proper modules and plugins.
+
+Signed-off-by: Paresh Bhagat <p-bhagat@ti.com>
+---
+ .../images/arago-default-image.bb             | 26 +++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/meta-arago-distro/recipes-core/images/arago-default-image.bb b/meta-arago-distro/recipes-core/images/arago-default-image.bb
+index e01f7c2f..b93534fc 100644
+--- a/meta-arago-distro/recipes-core/images/arago-default-image.bb
++++ b/meta-arago-distro/recipes-core/images/arago-default-image.bb
+@@ -43,3 +43,29 @@ IMAGE_INSTALL += "\
+     ${DEVTOOLS} \
+     docker \
+ "
++
++PIPEWIRE = " \
++    gstreamer1.0-pipewire \
++    libpipewire \
++    lua \
++    pipewire \
++    pipewire-alsa \
++    pipewire-alsa-card-profile \
++    pipewire-dev \
++    pipewire-modules-meta \
++    pipewire-pulse \
++    pipewire-spa-plugins-meta \
++    pipewire-spa-tools \
++    pipewire-tools \
++    speexdsp \
++    wireplumber \
++    wireplumber-dev \
++"
++
++IMAGE_INSTALL:append:am62dxx-evm = " ${PIPEWIRE}"
++IMAGE_INSTALL:append:am62xx-evm = " ${PIPEWIRE}"
++IMAGE_INSTALL:append:am62pxx-evm = " ${PIPEWIRE}"
++IMAGE_INSTALL:append:am62xx-lp-evm = " ${PIPEWIRE}"
++IMAGE_INSTALL:append:am62axx-evm = " ${PIPEWIRE}"
++IMAGE_INSTALL:append:am62xxsip-evm = " ${PIPEWIRE}"
++IMAGE_INSTALL:append:am62lxx-evm = " ${PIPEWIRE}"
+-- 
+2.34.1
+


### PR DESCRIPTION
Add patches for appnote (sdaa320) to enable PipeWire on TI Sitara devices.